### PR TITLE
Accept number array in TypeScript for number slice arguments

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1700,7 +1700,12 @@ fn adapter2ts(
         AdapterType::String => dst.push_str("string"),
         AdapterType::Externref => dst.push_str("any"),
         AdapterType::Bool => dst.push_str("boolean"),
-        AdapterType::Vector(kind) => dst.push_str(&kind.js_ty()),
+        AdapterType::Vector(kind) => {
+            dst.push_str(&kind.js_ty());
+            if let TypePosition::Argument = position {
+                dst.push_str(" | number[]");
+            }
+        }
         AdapterType::Option(ty) => {
             adapter2ts(ty, position, dst, refs);
             dst.push_str(match position {

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -6,6 +6,7 @@ pub mod enums;
 pub mod function_attrs;
 pub mod getters_setters;
 pub mod inspectable;
+pub mod number_slice;
 pub mod omit_definition;
 pub mod opt_args_and_ret;
 pub mod optional_fields;

--- a/crates/typescript-tests/src/number_slice.rs
+++ b/crates/typescript-tests/src/number_slice.rs
@@ -1,0 +1,16 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn fn_expects_number_vec(arg1: Vec<f32>) -> f32 {
+    arg1.into_iter().sum()
+}
+
+#[wasm_bindgen]
+pub fn fn_expects_number_slice(arg1: &[f64]) -> f64 {
+    arg1.iter().sum()
+}
+
+#[wasm_bindgen]
+pub fn fn_return_number_vec(arg1: u32) -> Vec<u32> {
+    (0..arg1).collect()
+}

--- a/crates/typescript-tests/src/number_slice.rs
+++ b/crates/typescript-tests/src/number_slice.rs
@@ -14,3 +14,8 @@ pub fn fn_expects_number_slice(arg1: &[f64]) -> f64 {
 pub fn fn_return_number_vec(arg1: u32) -> Vec<u32> {
     (0..arg1).collect()
 }
+
+#[wasm_bindgen]
+pub fn fn_u8_to_f32(arg1: &[u8]) -> Vec<f32> {
+    arg1.iter().map(|x| *x as f32).collect()
+}

--- a/crates/typescript-tests/src/number_slice.ts
+++ b/crates/typescript-tests/src/number_slice.ts
@@ -1,0 +1,12 @@
+import * as wbg from "../pkg/typescript_tests";
+import { expect, jest, test } from "@jest/globals";
+
+test("function calls", () => {
+  const fn_expects_number_vec = wbg.fn_expects_number_vec;
+  const fn_expects_number_slice = wbg.fn_expects_number_slice;
+  const fn_return_number_vec = wbg.fn_return_number_vec;
+
+  expect(fn_expects_number_vec([0.1, 2.2, 3.4, 5])).toBeCloseTo(10.7, 5);
+  expect(fn_expects_number_slice([0.1, 2.2, 3.4, 5])).toBeCloseTo(10.7, 5);
+  expect(fn_return_number_vec(5)).toEqual(new Uint32Array([0, 1, 2, 3, 4]));
+});

--- a/crates/typescript-tests/src/number_slice.ts
+++ b/crates/typescript-tests/src/number_slice.ts
@@ -10,3 +10,9 @@ test("function calls", () => {
   expect(fn_expects_number_slice([0.1, 2.2, 3.4, 5])).toBeCloseTo(10.7, 5);
   expect(fn_return_number_vec(5)).toEqual(new Uint32Array([0, 1, 2, 3, 4]));
 });
+
+test("integer truncating", () => {
+  const fn_u8_to_f32 = wbg.fn_u8_to_f32;
+  expect(fn_u8_to_f32([0, 128, 255, 2.9, -0x10, 0x21f]))
+    .toEqual(new Float32Array([0, 128, 255, 2, 0xf0, 0x1f]));
+});


### PR DESCRIPTION
For Rust type like `Box<[u32]>` in parameter, wasm-bindgen generates `Uint32Array` as type in the TypeScript declaration. However, the glue code generated uses [`TypedArray.set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set) internally to pass the content into the linear memory, and that method actually accepts array of number as well.

Having the type being only `TypedArray` forces consumer to create an extra `TypedArray` and copy content into it first, which should be unnecessary.